### PR TITLE
feat: add fetchContentFromURL function for fetching content from a external URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ func main() {
 
 	router.Get("/reference", func(w http.ResponseWriter, r *http.Request) {
 		htmlContent, err := scalar.ApiReferenceHTML(&scalar.Options{
-			SpecURL: "./docs/swagger.json",
+			// SpecURL: "https://generator3.swagger.io/openapi.json",// allow external URL or local path file
+			SpecURL: "./docs/swagger.json", 
 			CustomOptions: scalar.CustomOptions{
 				PageTitle: "Simple API",
 			},

--- a/scalar.go
+++ b/scalar.go
@@ -42,17 +42,26 @@ func ApiReferenceHTML(optionsInput *Options) (string, error) {
 	}
 
 	if options.SpecContent == nil && options.SpecURL != "" {
-		urlPath, err := ensureFileURL(options.SpecURL)
-		if err != nil {
-			return "", err
-		}
 
-		content, err := readFileFromURL(urlPath)
-		if err != nil {
-			return "", err
-		}
+		if strings.HasPrefix(options.SpecURL, "http") {
+			content, err := fetchContentFromURL(options.SpecURL)
+			if err != nil {
+				return "", err
+			}
+			options.SpecContent = content
+		} else {
+			urlPath, err := ensureFileURL(options.SpecURL)
+			if err != nil {
+				return "", err
+			}
 
-		options.SpecContent = string(content)
+			content, err := readFileFromURL(urlPath)
+			if err != nil {
+				return "", err
+			}
+
+			options.SpecContent = string(content)
+		}
 	}
 
 	dataConfig := safeJSONConfiguration(options)

--- a/types.go
+++ b/types.go
@@ -101,7 +101,7 @@ type Options struct {
 	CDN                string              `json:"cdn,omitempty"`
 	Theme              ThemeId             `json:"theme,omitempty"`
 	Layout             ReferenceLayoutType `json:"layout,omitempty"`
-	SpecURL            string              `json:"specUrl,omitempty"`
+	SpecURL            string              `json:"specUrl,omitempty"` // allow external URL ou local path file
 	SpecContent        interface{}         `json:"specContent,omitempty"`
 	Proxy              string              `json:"proxy,omitempty"`
 	IsEditable         bool                `json:"isEditable,omitempty"`

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,8 @@ package scalar
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -39,6 +41,22 @@ func ensureFileURL(filePath string) (string, error) {
 	}
 	resolvedPath := filepath.Join(currentDir, filePath)
 	return "file://" + resolvedPath, nil
+}
+
+// fetchContentFromURL reads the content from a URL and returns it as a string
+func fetchContentFromURL(fileURL string) (string, error) {
+	resp, err := http.Get(fileURL)
+	if err != nil {
+		return "", fmt.Errorf("error getting file content: %w", err)
+	}
+	defer resp.Body.Close()
+
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading file content: %w", err)
+	}
+
+	return string(content), nil
 }
 
 func readFileFromURL(fileURL string) ([]byte, error) {


### PR DESCRIPTION
This implementation allows you to enter an external URL for the `SpecURL` property. 
This makes it possible to use an OpenApi file hosted outside the current application.