### PR TITLE
feat: Add favicon support to Scalar API Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ func main() {
 			SpecURL: "./docs/swagger.json", 
 			CustomOptions: scalar.CustomOptions{
 				PageTitle: "Simple API",
+				FavIcon:   "/static/favicon.ico",
 			},
 			DarkMode: true,
 		})

--- a/scalar.go
+++ b/scalar.go
@@ -75,6 +75,14 @@ func ApiReferenceHTML(optionsInput *Options) (string, error) {
 		pageTitle = "Scalar API Reference"
 	}
 
+	var favIcon string
+
+	if options.CustomOptions.FavIcon != "" {
+		favIcon = options.CustomOptions.FavIcon
+	} else {
+		favIcon = ""
+	}
+
 	customThemeCss := CustomThemeCSS
 
 	if options.Theme != "" {
@@ -86,6 +94,7 @@ func ApiReferenceHTML(optionsInput *Options) (string, error) {
     <html>
       <head>
         <title>%s</title>
+		<link rel="icon" href="%s" />
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <style>%s</style>
@@ -95,5 +104,5 @@ func ApiReferenceHTML(optionsInput *Options) (string, error) {
         <script src="%s"></script>
       </body>
     </html>
-  `, pageTitle, customThemeCss, dataConfig, specContentHTML, options.CDN), nil
+  `, pageTitle, favIcon, customThemeCss, dataConfig, specContentHTML, options.CDN), nil
 }

--- a/types.go
+++ b/types.go
@@ -122,6 +122,7 @@ type Options struct {
 
 type CustomOptions struct {
 	PageTitle string `json:"pageTitle,omitempty"`
+	FavIcon   string `json:"favIcon,omitempty"`
 }
 
 // DefaultOptions configures the default settings for API Reference options


### PR DESCRIPTION
## Description

This pull request introduces the addition of a favicon. 

### Impact

This change is backward-compatible and does not affect existing documentation setups. It simply adds an optional feature for those who wish to utilize it.

### Testing

Verified that the favicon appears correctly.
Ensured that documentation generation remains unaffected when no favicon is specified.

Thank you for considering this enhancement! Looking forward to your feedback and suggestions.